### PR TITLE
Advanced linkrot checking

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,7 @@
         "FLASK_APP": "wsgi.py",
         "FLASK_ENV": "development",
         "SYS_VARS_PATH": "${workspaceFolder}/secrets",
+        "TIMES_FAILED_THRESHOLD": "2"
       },
       "args": [
         "run",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Flask secret key (`SECRET_KEY`)
 - SQLite path (`DB_PATH`)
 - Auth key for all non-GET operations (`AUTH_KEY`)
+- Integer number of times supposed rotted links should be checked (`TIMES_FAILED_THRESHOLD`)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - View all entries in the ring
 - Create, update, and delete entries
-- Basic linkrot checking
+- Linkrot checking, with Web Archive fallback url for dead links (when possible)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WebRing
+# Arcana Webring
 
-> Because.
+> Because everything on the Web eventually loops back onto itself.
 
 ## Required Secrets
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
     environment:
       - FLASK_ENV=production
       - SYS_VARS_PATH=/app/secrets
+      - TIMES_FAILED_THRESHOLD=5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
-name = "webring"
+name = "Arcana Webring"
 version = "0.1.0"
-description = "Because."
+description = "Because everything on the Web eventually loops back onto itself."
 authors = ["Caleb Ely <le717@users.noreply.github.com>"]
 license = "MIT"
 

--- a/src/core/database/linkrot.py
+++ b/src/core/database/linkrot.py
@@ -63,10 +63,7 @@ def __delete(uuid: str):
 
 def check_all() -> list[RotResult]:
     """Check all links for rotting."""
-    results = []
-    for link in weblink.get_all():
-        results.append(RotResult(id=link.id, url=link.url, result=__ping_url(link.url)))
-    return results
+    return [check_one(link.id) for link in weblink.get_all()]
 
 
 def check_one(uuid: str) -> RotResult:

--- a/src/core/database/linkrot.py
+++ b/src/core/database/linkrot.py
@@ -74,7 +74,7 @@ def check_one(uuid: str) -> RotResult:
     # The site could be pinged, so we all good
     link = weblink.get(uuid)
     if __ping_url(link.url):
-        result = RotResult(id=link.id, url=link.url, result=RotStates.NO)
+        result = RotResult(id=link.id, url=link.url, result=RotStates.NO.value)
         __delete(uuid)
         weblink.update(
             {
@@ -86,7 +86,9 @@ def check_one(uuid: str) -> RotResult:
 
     # We could not ping the site, decide the next step
     else:
-        result = RotResult(id=link.id, url=link.url, result=__record_failure(link))
+        result = RotResult(
+            id=link.id, url=link.url, result=__record_failure(link).value
+        )
     return result
 
 

--- a/src/core/database/linkrot.py
+++ b/src/core/database/linkrot.py
@@ -1,8 +1,9 @@
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 import requests
 
-from src.core.database import weblink as db
+from src.core.database import weblink
+from src.core.database.schema import RottedLinks, WebLink, db
 from src.core.models.RotStates import RotStates
 
 
@@ -10,30 +11,87 @@ __all__ = ["check_all", "check_one"]
 
 
 class RotResult(TypedDict):
-    uuid: str
+    id: str
     url: str
     result: str
 
 
-def __check(url: str) -> RotStates:
+def __ping_url(url: str) -> bool:
     """Check a link for rotting."""
     try:
         r = requests.head(url)
-        if r.status_code == requests.codes.ok:
-            return RotStates.NO.value
+        return r.status_code == requests.codes.ok
     except Exception:
-        return RotStates.YES.value
+        return False
+
+
+def __create(data: WebLink) -> Literal[True]:
+    rot_entry = RottedLinks(id=data.id, times_failed=1)
+    db.session.add(rot_entry)
+    db.session.commit()
+    db.session.refresh(rot_entry)
+    return True
+
+
+def __get(uuid: str) -> RottedLinks:
+    return RottedLinks.query.filter_by(id=uuid).first()
+
+
+def __update(data: RottedLinks) -> Literal[True]:
+    db.session.query(RottedLinks).filter_by(id=data.id).update(
+        {"times_failed": data.times_failed + 1}, synchronize_session="fetch"
+    )
+    db.session.commit()
+    return True
+
+
+def __delete(uuid: str):
+    if exists := __get(uuid):
+        db.session.delete(exists)
+        db.session.commit()
+    return True
 
 
 def check_all() -> list[RotResult]:
     """Check all links for rotting."""
     results = []
-    for link in db.get_all():
-        results.append(RotResult(uuid=link.id, url=link.url, result=__check(link.url)))
+    for link in weblink.get_all():
+        results.append(RotResult(id=link.id, url=link.url, result=__ping_url(link.url)))
     return results
 
 
 def check_one(uuid: str) -> RotResult:
     """Check a single link for rotting."""
-    link = db.get(uuid)
-    return RotResult(uuid=link.id, url=link.url, result=__check(link.url))
+    # The site could be pinged, so we all good
+    link = weblink.get(uuid)
+    if __ping_url(link.url):
+        result = RotResult(id=link.id, url=link.url, result=RotStates.NO)
+        __delete(uuid)
+
+    # We could not ping the site, decide the next step
+    else:
+        result = RotResult(id=link.id, url=link.url, result=__record_failure(link))
+    return result
+
+
+def __record_failure(data: WebLink) -> RotStates:
+    TIMES_FAILED_THRESHOLD = 5
+
+    existing = __get(data.id)
+
+    # We don't have an existing failure record, so make one
+    if existing is None:
+        __create(data)
+        weblink.update({"id": data.id, "rotted": RotStates.MAYBE.value})
+        return RotStates.MAYBE
+
+    # We have an existing failure record, update the failure count
+    print(existing.times_failed)
+    if existing.times_failed < TIMES_FAILED_THRESHOLD:
+        __update(existing)
+        return RotStates.MAYBE
+
+    # The failure has occurred too often, declare a dead link
+    weblink.update({"id": data.id, "rotted": RotStates.YES.value})
+    __delete(data.id)
+    return RotStates.YES

--- a/src/core/database/linkrot.py
+++ b/src/core/database/linkrot.py
@@ -1,6 +1,7 @@
 from typing import Literal, TypedDict, Union
 
 import requests
+import sys_vars
 
 from src.core.database import weblink
 from src.core.database.schema import RottedLinks, WebLink, db
@@ -90,7 +91,7 @@ def check_one(uuid: str) -> RotResult:
 
 
 def __record_failure(data: WebLink) -> RotStates:
-    TIMES_FAILED_THRESHOLD = 5
+    TIMES_FAILED_THRESHOLD = sys_vars.get_int("TIMES_FAILED_THRESHOLD")
 
     # We don't have an existing failure record, so make one
     existing = __get(data.id)

--- a/src/core/database/weblink.py
+++ b/src/core/database/weblink.py
@@ -47,9 +47,12 @@ def get(uuid: str) -> Optional[WebLink]:
     return WebLink.query.filter_by(id=uuid).first()
 
 
-def get_all() -> list[WebLink]:
+def get_all(with_rotted: bool = False) -> list[WebLink]:
     """Get all weblinks."""
-    return WebLink.query.all()
+    filters = []
+    if not with_rotted:
+        filters.append(WebLink.rotted == "no")
+    return WebLink.query.filter(*filters).all()
 
 
 def update(data: OrderedDict) -> bool:

--- a/src/core/database/weblink.py
+++ b/src/core/database/weblink.py
@@ -51,7 +51,7 @@ def get_all(with_rotted: bool = False) -> list[WebLink]:
     """Get all weblinks."""
     filters = []
     if not with_rotted:
-        filters.append(WebLink.rotted == "no")
+        filters.append(WebLink.rotted != "yes")
     return WebLink.query.filter(*filters).all()
 
 

--- a/src/views/root.py
+++ b/src/views/root.py
@@ -12,8 +12,11 @@ from src.core.database import weblink as db
 class WebRing(MethodView):
     @root.response(200, models.WebLink(many=True))
     def get(self):
-        """Fetch webring items."""
-        return db.get_all()
+        """Fetch webring items.
+
+        This will return rotted links in the result set.
+        """
+        return db.get_all(with_rotted=True)
 
     @root.arguments(models.AuthKey, location="query", as_kwargs=True)
     @root.arguments(models.WebLinkCreate, location="json", as_kwargs=True)


### PR DESCRIPTION
Closes #2.

Checks and records a link's possible rotted status. If failed, sets `rotted` to `maybe` until check threshold is reached. At that point, if still failed, the web archive is checked. If we get a url from it, that link is used and `rotted` is `yes`. If no WA url, link title is marked as dead. Link can be revived and marked as alive if URL is changed to a valid one.

### TODO
- [x] I just realized that links with `rotted: yes` are still checked. Don't do that.
- [x] Except fixing that broke the checking. *sigh*